### PR TITLE
Adding Spring Milestone repo to the pluginRepositories in the POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -124,6 +124,14 @@
 
 	<pluginRepositories>
 		<pluginRepository>
+			<id>org.springframework.maven.milestone</id>
+			<name>Spring Maven Milestone Repository</name>
+			<url>http://repo.spring.io/milestone</url>
+			<snapshots>
+				<enabled>false</enabled>
+			</snapshots>
+		</pluginRepository>
+		<pluginRepository>
 			<id>spring-snapshots</id>
 			<name>Spring Snapshots</name>
 			<url>http://repo.spring.io/snapshot</url>


### PR DESCRIPTION
Doing this to stop build error due to a transitive dependency on a Spring Integration milestone build.
